### PR TITLE
refactor(member): writer → writerName 필드 통일

### DIFF
--- a/apps/member/src/api/community/comment/api.model.ts
+++ b/apps/member/src/api/community/comment/api.model.ts
@@ -23,9 +23,7 @@ export type CommentResponseDto = {
   children: CommentResponseDto[];
 };
 
-export type MyCommentResponseDto = Omit<CommentResponseDto, "writerName"> & {
-  writer: string;
-};
+export type MyCommentResponseDto = CommentResponseDto;
 
 export type GetMyCommentsResponse = ApiResponse<
   PagedResponse<MyCommentResponseDto>

--- a/apps/member/src/api/community/comment/api.query.ts
+++ b/apps/member/src/api/community/comment/api.query.ts
@@ -62,15 +62,7 @@ export const commentQueries = {
       queryFn: () => getMyComments(params),
       select: (data): PagedResponse<CommentResponseDto> =>
         data.ok
-          ? {
-              ...data.data.data,
-              items: data.data.data.items.map(({ writer, ...rest }) => ({
-                ...rest,
-                writerName: writer,
-                isOwner: true,
-                children: [],
-              })),
-            }
+          ? data.data.data
           : {
               items: [],
               currentPage: 0,
@@ -95,18 +87,7 @@ export const commentQueries = {
             data: { hasNext: false, items: [], currentPage: 0 },
           } as unknown as GetCommentsResponse;
         }
-        return {
-          ...res.data,
-          data: {
-            ...res.data.data,
-            items: res.data.data.items.map(({ writer, ...rest }) => ({
-              ...rest,
-              writerName: writer,
-              isOwner: true,
-              children: [],
-            })),
-          },
-        };
+        return res.data;
       },
       initialPageParam: 0,
       getNextPageParam: (lastPage) =>


### PR DESCRIPTION
## Summary

BE에서 writerName으로 필드명을 통일함에 따라, 댓글 관련 타입/쿼리에서 writer와 writerName이 혼용되던 부분을 writerName으로 일괄 정리하고 중간 매핑 코드를 제거합니다.

## Tasks

- [x] `apps/member/src/api/community/comment/api.model.ts` — `MyCommentResponseDto`에서 writer 필드 제거, CommentResponseDto로 통일
- [x] `apps/member/src/api/community/comment/api.query.ts` — `writer → writerName` 중간 매핑 코드 제거

<img width="2305" height="1045" alt="image" src="https://github.com/user-attachments/assets/40b4f11c-2f33-457d-95ce-7941b214b8a9" />


close #43