### PR TITLE
refactor: admin 페이지 컴포넌트/유틸 함수 분리

### DIFF
--- a/apps/member/src/api/activity/api.model.ts
+++ b/apps/member/src/api/activity/api.model.ts
@@ -27,6 +27,12 @@ export type GetActivitiyByCategoryResponse = BasePaginationResponse<
 >;
 
 export type GetActivitiyByStatusRequest = {
+  activityGroupStatus: ActivityStatus;
+  page: number;
+  size: number;
+};
+
+export type GetActivityJoinedRequest = {
   status: ActivityStatus;
   page: number;
   size: number;

--- a/apps/member/src/api/activity/api.query.ts
+++ b/apps/member/src/api/activity/api.query.ts
@@ -14,6 +14,7 @@ import type {
   GetActivitiyByStatusRequest,
   GetActivitiyDetailRequest,
   GetActivityApplicationsRequest,
+  GetActivityJoinedRequest,
   PatchActivityChangeStatusRequest,
   PatchActivityMemberStatusRequest,
   PatchActivityUpdateRequest,
@@ -48,7 +49,7 @@ export const activityQueries = {
   detailKey: (request: GetActivitiyDetailRequest) =>
     [...activityQueryKey, "detail", request.activityGroupId] as const,
   appliedKey: () => [...activityQueryKey, "applied"] as const,
-  joinedKey: (request?: GetActivitiyByStatusRequest) =>
+  joinedKey: (request?: GetActivityJoinedRequest) =>
     [...activityQueryKey, "joined", request] as const,
   applicationsKey: (request: GetActivityApplicationsRequest) =>
     [...activityQueryKey, "applications", request.activityGroupId] as const,
@@ -99,7 +100,7 @@ export const activityQueries = {
       staleTime: Number.POSITIVE_INFINITY, // invalidate 시에만 재요청
     }),
 
-  getActivityJoinedQuery: (request: GetActivitiyByStatusRequest) =>
+  getActivityJoinedQuery: (request: GetActivityJoinedRequest) =>
     queryOptions({
       queryKey: activityQueries.joinedKey(request),
       queryFn: async () => {
@@ -206,14 +207,8 @@ export const activityQueries = {
   }),
 
   patchActivityStatusMutation: mutationOptions({
-    mutationFn: async ({
-      activityGroupId,
-      activityGroupStatus,
-    }: PatchActivityChangeStatusRequest) => {
-      const res = await patchActivityStatus(
-        activityGroupId,
-        activityGroupStatus,
-      );
+    mutationFn: async (request: PatchActivityChangeStatusRequest) => {
+      const res = await patchActivityStatus(request);
       if (!res.ok)
         throw new Error(res.error.message ?? "활동 상태 변경에 실패했습니다.");
       return res.data;

--- a/apps/member/src/api/activity/getActivityByStatus.ts
+++ b/apps/member/src/api/activity/getActivityByStatus.ts
@@ -8,7 +8,7 @@ import type {
 export const getActivityByStatus = (request: GetActivitiyByStatusRequest) =>
   authApi.get<GetActivitiyByStatusResponse>(END_POINT.ACTIVITY.LIST_BY_STATUS, {
     searchParams: {
-      status: request.status,
+      activityGroupStatus: request.activityGroupStatus,
       page: request.page,
       size: request.size,
     },

--- a/apps/member/src/api/activity/getActivityJoined.ts
+++ b/apps/member/src/api/activity/getActivityJoined.ts
@@ -1,11 +1,11 @@
 import { authApi, END_POINT } from "@/api/config";
 
 import type {
-  GetActivitiyByStatusRequest,
+  GetActivityJoinedRequest,
   GetActivitiyByStatusResponse,
 } from "./api.model";
 
-export const getActivityJoined = (request: GetActivitiyByStatusRequest) =>
+export const getActivityJoined = (request: GetActivityJoinedRequest) =>
   authApi.get<GetActivitiyByStatusResponse>(
     END_POINT.ACTIVITY.MY_ACTIVITY_JOINED,
     {

--- a/apps/member/src/api/activity/patchActivityStatus.ts
+++ b/apps/member/src/api/activity/patchActivityStatus.ts
@@ -1,16 +1,14 @@
 import { authApi, END_POINT } from "@/api/config";
 import type { BaseApiResponse } from "@/api/config/api-base-types";
 
-import type {
-  ActivityStatus,
-  PatchActivityChangeStatusRequest,
-} from "./api.model";
+import type { PatchActivityChangeStatusRequest } from "./api.model";
 
-export const patchActivityStatus = (
-  activityGroupId: number,
-  activityGroupStatus: ActivityStatus,
-) =>
-  authApi.patch<BaseApiResponse<unknown>, PatchActivityChangeStatusRequest>(
+export const patchActivityStatus = ({
+  activityGroupId,
+  activityGroupStatus,
+}: PatchActivityChangeStatusRequest) =>
+  authApi.patch<BaseApiResponse<unknown>, undefined>(
     END_POINT.ACTIVITY.CHANGE_STATUS(activityGroupId),
-    { activityGroupId, activityGroupStatus },
+    undefined,
+    { searchParams: { activityGroupStatus } },
   );

--- a/apps/member/src/api/application/api.model.ts
+++ b/apps/member/src/api/application/api.model.ts
@@ -1,0 +1,35 @@
+import type { PaginationParams } from "@/api/config";
+
+export type ApplicationType = "NORMAL" | "OPERATION" | "CORE_TEAM";
+
+export type ApplicationResponseDto = {
+  studentId: string;
+  recruitmentId: number;
+  name: string;
+  contact: string;
+  email: string;
+  department: string;
+  grade: number;
+  // TODO: 백엔드 응답 필드 확인
+  studentStatus?: string;
+  birth: string;
+  address: string;
+  interests: string;
+  otherActivities: string;
+  githubUrl: string;
+  applicationType: ApplicationType;
+  isPass: boolean;
+  updatedAt: string;
+  createdAt: string;
+};
+
+export type GetApplicationConditionsParams = PaginationParams & {
+  recruitmentId?: number;
+  studentId?: string;
+  isPass?: boolean;
+};
+
+export type ApplicationActionParams = {
+  recruitmentId: number;
+  studentId: string;
+};

--- a/apps/member/src/api/application/api.query.ts
+++ b/apps/member/src/api/application/api.query.ts
@@ -1,0 +1,54 @@
+import { mutationOptions, queryOptions } from "@tanstack/react-query";
+
+import { TOAST_MESSAGES } from "@/constants";
+import { showErrorToast, showSuccessToast } from "@/utils/toast";
+
+import type {
+  ApplicationActionParams,
+  GetApplicationConditionsParams,
+} from "./api.model";
+import { getApplicationConditions } from "./getApplicationConditions";
+import { patchApplicationApprove } from "./patchApplicationApprove";
+import { patchApplicationReject } from "./patchApplicationReject";
+
+export const applicationKeys = {
+  all: ["application"] as const,
+  conditions: (params?: GetApplicationConditionsParams) =>
+    [...applicationKeys.all, "conditions", params] as const,
+};
+
+export const applicationQueries = {
+  getApplicationConditionsQuery: (params?: GetApplicationConditionsParams) =>
+    queryOptions({
+      queryKey: applicationKeys.conditions(params),
+      queryFn: () => getApplicationConditions(params),
+    }),
+
+  patchApplicationApproveMutation: mutationOptions<
+    unknown,
+    Error,
+    ApplicationActionParams
+  >({
+    mutationFn: (params) => patchApplicationApprove(params),
+    onSuccess: () => {
+      showSuccessToast(TOAST_MESSAGES.APPLICATION_APPROVE);
+    },
+    onError: () => {
+      showErrorToast(TOAST_MESSAGES.APPLICATION_APPROVE);
+    },
+  }),
+
+  patchApplicationRejectMutation: mutationOptions<
+    unknown,
+    Error,
+    ApplicationActionParams
+  >({
+    mutationFn: (params) => patchApplicationReject(params),
+    onSuccess: () => {
+      showSuccessToast(TOAST_MESSAGES.APPLICATION_REJECT);
+    },
+    onError: () => {
+      showErrorToast(TOAST_MESSAGES.APPLICATION_REJECT);
+    },
+  }),
+};

--- a/apps/member/src/api/application/getApplicationConditions.ts
+++ b/apps/member/src/api/application/getApplicationConditions.ts
@@ -1,0 +1,29 @@
+import type { ApiResponse, PagedResponse } from "@/api/config";
+import { authApi, END_POINT } from "@/api/config";
+
+import type {
+  ApplicationResponseDto,
+  GetApplicationConditionsParams,
+} from "./api.model";
+
+export function getApplicationConditions(
+  params?: GetApplicationConditionsParams,
+) {
+  const searchParams = new URLSearchParams();
+  if (params?.recruitmentId !== undefined)
+    searchParams.set("recruitmentId", String(params.recruitmentId));
+  if (params?.studentId) searchParams.set("studentId", params.studentId);
+  if (params?.isPass !== undefined)
+    searchParams.set("isPass", String(params.isPass));
+  if (params?.page !== undefined) searchParams.set("page", String(params.page));
+  if (params?.size !== undefined) searchParams.set("size", String(params.size));
+  params?.sortBy?.forEach((s) => searchParams.append("sortBy", s));
+  params?.sortDirection?.forEach((d) =>
+    searchParams.append("sortDirection", d),
+  );
+
+  return authApi.get<ApiResponse<PagedResponse<ApplicationResponseDto>>>(
+    END_POINT.APPLICATION.CONDITIONS,
+    { searchParams },
+  );
+}

--- a/apps/member/src/api/application/index.ts
+++ b/apps/member/src/api/application/index.ts
@@ -1,0 +1,2 @@
+export * from "./api.model";
+export { applicationKeys, applicationQueries } from "./api.query";

--- a/apps/member/src/api/application/patchApplicationApprove.ts
+++ b/apps/member/src/api/application/patchApplicationApprove.ts
@@ -1,0 +1,14 @@
+import type { ApiResponse } from "@/api/config";
+import { authApi, END_POINT } from "@/api/config";
+
+import type { ApplicationActionParams } from "./api.model";
+
+export function patchApplicationApprove({
+  recruitmentId,
+  studentId,
+}: ApplicationActionParams) {
+  return authApi.patch<ApiResponse<string>, undefined>(
+    END_POINT.APPLICATION.APPROVE(recruitmentId, studentId),
+    undefined,
+  );
+}

--- a/apps/member/src/api/application/patchApplicationReject.ts
+++ b/apps/member/src/api/application/patchApplicationReject.ts
@@ -1,0 +1,14 @@
+import type { ApiResponse } from "@/api/config";
+import { authApi, END_POINT } from "@/api/config";
+
+import type { ApplicationActionParams } from "./api.model";
+
+export function patchApplicationReject({
+  recruitmentId,
+  studentId,
+}: ApplicationActionParams) {
+  return authApi.patch<ApiResponse<string>, undefined>(
+    END_POINT.APPLICATION.REJECT(recruitmentId, studentId),
+    undefined,
+  );
+}

--- a/apps/member/src/api/config/api-endpoint.ts
+++ b/apps/member/src/api/config/api-endpoint.ts
@@ -12,6 +12,25 @@ export const END_POINT = {
     INFO: "members/my-profile",
     UPDATE: (memberId: string) => `members/${memberId}`,
   },
+  MEMBER: {
+    BASE: "members",
+    DETAIL: (memberId: string) => `members/${memberId}`,
+    ROLES_LIST: "members/roles",
+    ROLE: (memberId: string) => `members/${memberId}/roles`,
+    PASSWORD_RESEND: (memberId: string) =>
+      `members/password/${memberId}/resend`,
+  },
+  APPLICATION: {
+    CONDITIONS: "applications/conditions",
+    APPROVE: (recruitmentId: number, studentId: string) =>
+      `applications/approve/${recruitmentId}/${studentId}`,
+    REJECT: (recruitmentId: number, studentId: string) =>
+      `applications/reject/${recruitmentId}/${studentId}`,
+  },
+  RECRUITMENT: {
+    BASE: "recruitments",
+    OPEN: "recruitments/open",
+  },
   COMMUNITY: {
     BOARD: {
       BASE: "boards",
@@ -55,7 +74,7 @@ export const END_POINT = {
   },
   ACTIVITY: {
     LIST_BY_CATEGORY: "activity-group/member/list",
-    LIST_BY_STATUS: "activity-group/status/list",
+    LIST_BY_STATUS: "activity-group/member/status",
     DETAIL: (activityGroupId: number) =>
       `activity-group/member/${activityGroupId}`,
     APPLY: "activity-group/member/apply",

--- a/apps/member/src/api/member/api.model.ts
+++ b/apps/member/src/api/member/api.model.ts
@@ -1,0 +1,51 @@
+import type { PaginationParams } from "@/api/config";
+
+export type MemberRole = "GUEST" | "USER" | "ADMIN" | "SUPER";
+
+export type StudentStatus = "CURRENT" | "ON_LEAVE" | "GRADUATED";
+
+export type MemberResponseDto = {
+  id: string;
+  name: string;
+  contact: string;
+  email: string;
+  department: string;
+  grade: number;
+  birth: string;
+  address: string;
+  interests: string;
+  githubUrl: string;
+  studentStatus: StudentStatus;
+  imageUrl: string;
+  role: MemberRole;
+  lastLoginTime: string;
+  loanSuspensionDate: string;
+  isOtpEnabled: boolean;
+  createdAt: string;
+};
+
+export type MemberRoleInfoResponseDto = {
+  id: string;
+  name: string;
+  role: MemberRole;
+  // TODO: 역할별 회원 목록 응답 필드 백엔드 확인
+  department?: string;
+  grade?: number;
+  studentStatus?: StudentStatus;
+  createdAt?: string;
+};
+
+export type GetMembersParams = PaginationParams & {
+  id?: string;
+  name?: string;
+};
+
+export type GetMembersByRoleParams = PaginationParams & {
+  memberId?: string;
+  memberName?: string;
+  role?: MemberRole;
+};
+
+export type ChangeMemberRoleRequest = {
+  role: MemberRole;
+};

--- a/apps/member/src/api/member/api.query.ts
+++ b/apps/member/src/api/member/api.query.ts
@@ -1,0 +1,71 @@
+import { mutationOptions, queryOptions } from "@tanstack/react-query";
+
+import { TOAST_MESSAGES } from "@/constants";
+import { showErrorToast, showSuccessToast } from "@/utils/toast";
+
+import type {
+  ChangeMemberRoleRequest,
+  GetMembersByRoleParams,
+  GetMembersParams,
+} from "./api.model";
+import { deleteMember } from "./deleteMember";
+import { getMembers } from "./getMembers";
+import { getMembersByRole } from "./getMembersByRole";
+import { patchMemberRole } from "./patchMemberRole";
+import { postPasswordResend } from "./postPasswordResend";
+
+export const memberKeys = {
+  all: ["member"] as const,
+  list: (params?: GetMembersParams) =>
+    [...memberKeys.all, "list", params] as const,
+  byRole: (params?: GetMembersByRoleParams) =>
+    [...memberKeys.all, "by-role", params] as const,
+};
+
+export const memberQueries = {
+  getMembersQuery: (params?: GetMembersParams) =>
+    queryOptions({
+      queryKey: memberKeys.list(params),
+      queryFn: () => getMembers(params),
+    }),
+
+  getMembersByRoleQuery: (params?: GetMembersByRoleParams) =>
+    queryOptions({
+      queryKey: memberKeys.byRole(params),
+      queryFn: () => getMembersByRole(params),
+    }),
+
+  patchMemberRoleMutation: mutationOptions<
+    unknown,
+    Error,
+    { memberId: string; body: ChangeMemberRoleRequest }
+  >({
+    mutationFn: ({ memberId, body }) => patchMemberRole(memberId, body),
+    onSuccess: () => {
+      showSuccessToast(TOAST_MESSAGES.MEMBER_ROLE_UPDATE);
+    },
+    onError: () => {
+      showErrorToast(TOAST_MESSAGES.MEMBER_ROLE_UPDATE);
+    },
+  }),
+
+  deleteMemberMutation: mutationOptions<unknown, Error, string>({
+    mutationFn: (memberId: string) => deleteMember(memberId),
+    onSuccess: () => {
+      showSuccessToast(TOAST_MESSAGES.MEMBER_DELETE);
+    },
+    onError: () => {
+      showErrorToast(TOAST_MESSAGES.MEMBER_DELETE);
+    },
+  }),
+
+  postPasswordResendMutation: mutationOptions<unknown, Error, string>({
+    mutationFn: (memberId: string) => postPasswordResend(memberId),
+    onSuccess: () => {
+      showSuccessToast(TOAST_MESSAGES.MEMBER_PASSWORD_RESEND);
+    },
+    onError: () => {
+      showErrorToast(TOAST_MESSAGES.MEMBER_PASSWORD_RESEND);
+    },
+  }),
+};

--- a/apps/member/src/api/member/deleteMember.ts
+++ b/apps/member/src/api/member/deleteMember.ts
@@ -1,0 +1,6 @@
+import type { ApiResponse } from "@/api/config";
+import { authApi, END_POINT } from "@/api/config";
+
+export function deleteMember(memberId: string) {
+  return authApi.del<ApiResponse<string>>(END_POINT.MEMBER.DETAIL(memberId));
+}

--- a/apps/member/src/api/member/getMembers.ts
+++ b/apps/member/src/api/member/getMembers.ts
@@ -1,0 +1,21 @@
+import type { ApiResponse, PagedResponse } from "@/api/config";
+import { authApi, END_POINT } from "@/api/config";
+
+import type { GetMembersParams, MemberResponseDto } from "./api.model";
+
+export function getMembers(params?: GetMembersParams) {
+  const searchParams = new URLSearchParams();
+  if (params?.id) searchParams.set("id", params.id);
+  if (params?.name) searchParams.set("name", params.name);
+  if (params?.page !== undefined) searchParams.set("page", String(params.page));
+  if (params?.size !== undefined) searchParams.set("size", String(params.size));
+  params?.sortBy?.forEach((s) => searchParams.append("sortBy", s));
+  params?.sortDirection?.forEach((d) =>
+    searchParams.append("sortDirection", d),
+  );
+
+  return authApi.get<ApiResponse<PagedResponse<MemberResponseDto>>>(
+    END_POINT.MEMBER.BASE,
+    { searchParams },
+  );
+}

--- a/apps/member/src/api/member/getMembersByRole.ts
+++ b/apps/member/src/api/member/getMembersByRole.ts
@@ -1,0 +1,25 @@
+import type { ApiResponse, PagedResponse } from "@/api/config";
+import { authApi, END_POINT } from "@/api/config";
+
+import type {
+  GetMembersByRoleParams,
+  MemberRoleInfoResponseDto,
+} from "./api.model";
+
+export function getMembersByRole(params?: GetMembersByRoleParams) {
+  const searchParams = new URLSearchParams();
+  if (params?.memberId) searchParams.set("memberId", params.memberId);
+  if (params?.memberName) searchParams.set("memberName", params.memberName);
+  if (params?.role) searchParams.set("role", params.role);
+  if (params?.page !== undefined) searchParams.set("page", String(params.page));
+  if (params?.size !== undefined) searchParams.set("size", String(params.size));
+  params?.sortBy?.forEach((s) => searchParams.append("sortBy", s));
+  params?.sortDirection?.forEach((d) =>
+    searchParams.append("sortDirection", d),
+  );
+
+  return authApi.get<ApiResponse<PagedResponse<MemberRoleInfoResponseDto>>>(
+    END_POINT.MEMBER.ROLES_LIST,
+    { searchParams },
+  );
+}

--- a/apps/member/src/api/member/index.ts
+++ b/apps/member/src/api/member/index.ts
@@ -1,0 +1,2 @@
+export * from "./api.model";
+export { memberKeys, memberQueries } from "./api.query";

--- a/apps/member/src/api/member/patchMemberRole.ts
+++ b/apps/member/src/api/member/patchMemberRole.ts
@@ -1,0 +1,14 @@
+import type { ApiResponse } from "@/api/config";
+import { authApi, END_POINT } from "@/api/config";
+
+import type { ChangeMemberRoleRequest } from "./api.model";
+
+export function patchMemberRole(
+  memberId: string,
+  body: ChangeMemberRoleRequest,
+) {
+  return authApi.patch<ApiResponse<string>, ChangeMemberRoleRequest>(
+    END_POINT.MEMBER.ROLE(memberId),
+    body,
+  );
+}

--- a/apps/member/src/api/member/postPasswordResend.ts
+++ b/apps/member/src/api/member/postPasswordResend.ts
@@ -1,0 +1,9 @@
+import type { ApiResponse } from "@/api/config";
+import { authApi, END_POINT } from "@/api/config";
+
+export function postPasswordResend(memberId: string) {
+  return authApi.post<ApiResponse<string>, undefined>(
+    END_POINT.MEMBER.PASSWORD_RESEND(memberId),
+    undefined,
+  );
+}

--- a/apps/member/src/api/recruitment/api.model.ts
+++ b/apps/member/src/api/recruitment/api.model.ts
@@ -1,0 +1,5 @@
+export type OpenRecruitmentResponseDto = {
+  id: number;
+  title: string;
+  [key: string]: unknown;
+};

--- a/apps/member/src/api/recruitment/api.query.ts
+++ b/apps/member/src/api/recruitment/api.query.ts
@@ -1,0 +1,16 @@
+import { queryOptions } from "@tanstack/react-query";
+
+import { getOpenRecruitments } from "./getOpenRecruitments";
+
+export const recruitmentKeys = {
+  all: ["recruitment"] as const,
+  open: () => [...recruitmentKeys.all, "open"] as const,
+};
+
+export const recruitmentQueries = {
+  getOpenRecruitmentsQuery: () =>
+    queryOptions({
+      queryKey: recruitmentKeys.open(),
+      queryFn: () => getOpenRecruitments(),
+    }),
+};

--- a/apps/member/src/api/recruitment/getOpenRecruitments.ts
+++ b/apps/member/src/api/recruitment/getOpenRecruitments.ts
@@ -1,0 +1,44 @@
+import type { ApiResponse } from "@/api/config";
+import { authApi, END_POINT } from "@/api/config";
+import type { ApiResult } from "@/api/config/api-client-handler";
+
+import type { OpenRecruitmentResponseDto } from "./api.model";
+
+export async function getOpenRecruitments(): Promise<
+  ApiResult<ApiResponse<OpenRecruitmentResponseDto[]>>
+> {
+  // TODO: 응답 스키마 백엔드 확인
+  const res = await authApi.get<ApiResponse<unknown>>(
+    END_POINT.RECRUITMENT.OPEN,
+  );
+  if (!res.ok) return res;
+
+  const raw = res.data.data;
+  const list = Array.isArray(raw)
+    ? raw
+    : isObject(raw) && Array.isArray(raw.items)
+      ? raw.items
+      : [];
+
+  return {
+    ...res,
+    data: {
+      ...res.data,
+      data: list.filter(isOpenRecruitment),
+    },
+  };
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function isOpenRecruitment(
+  value: unknown,
+): value is OpenRecruitmentResponseDto {
+  return (
+    isObject(value) &&
+    typeof value.id === "number" &&
+    typeof value.title === "string"
+  );
+}

--- a/apps/member/src/api/recruitment/index.ts
+++ b/apps/member/src/api/recruitment/index.ts
@@ -1,0 +1,2 @@
+export * from "./api.model";
+export { recruitmentKeys, recruitmentQueries } from "./api.query";

--- a/apps/member/src/app/route/config.tsx
+++ b/apps/member/src/app/route/config.tsx
@@ -1,5 +1,6 @@
 import { createBrowserRouter } from "react-router";
 
+import { AdminGuard } from "@/components/admin";
 import { AuthProvider } from "@/components/auth";
 
 import { ROUTE } from "@/constants";
@@ -25,6 +26,12 @@ import {
   SupportPage,
   SupportWritePage,
   LoginPage,
+  AdminHomePage,
+  AdminSupportPage,
+  AdminActivityPage,
+  AdminLibraryPage,
+  AdminReportPage,
+  AdminMemberPage,
 } from "@/pages";
 
 import ActivityLayout from "../layout/ActivityLayout";
@@ -122,6 +129,65 @@ const supportRoutes = [
   },
 ];
 
+const adminRoutes = [
+  {
+    path: ROUTE.ADMIN,
+    element: (
+      <AdminGuard>
+        <AdminHomePage />
+      </AdminGuard>
+    ),
+  },
+  {
+    path: ROUTE.ADMIN_SUPPORT,
+    element: (
+      <AdminGuard>
+        <AdminSupportPage />
+      </AdminGuard>
+    ),
+  },
+  {
+    path: `${ROUTE.ADMIN_SUPPORT}/:id`,
+    element: (
+      <AdminGuard>
+        <SupportDetailPage />
+      </AdminGuard>
+    ),
+  },
+  {
+    path: ROUTE.ADMIN_ACTIVITY,
+    element: (
+      <AdminGuard>
+        <AdminActivityPage />
+      </AdminGuard>
+    ),
+  },
+  {
+    path: ROUTE.ADMIN_LIBRARY,
+    element: (
+      <AdminGuard>
+        <AdminLibraryPage />
+      </AdminGuard>
+    ),
+  },
+  {
+    path: ROUTE.ADMIN_REPORT,
+    element: (
+      <AdminGuard>
+        <AdminReportPage />
+      </AdminGuard>
+    ),
+  },
+  {
+    path: ROUTE.ADMIN_MEMBER,
+    element: (
+      <AdminGuard>
+        <AdminMemberPage />
+      </AdminGuard>
+    ),
+  },
+];
+
 const protectedRoutes = [
   {
     element: <AuthProvider protect />,
@@ -132,6 +198,7 @@ const protectedRoutes = [
       ...libraryRoutes,
       ...myRoutes,
       ...supportRoutes,
+      ...adminRoutes,
     ],
   },
 ];

--- a/apps/member/src/components/admin/ActivityAdminCard.tsx
+++ b/apps/member/src/components/admin/ActivityAdminCard.tsx
@@ -1,0 +1,112 @@
+import { Button, Chip } from "@clab/design-system";
+import { GoPeople } from "react-icons/go";
+import { PiCrownSimpleFill } from "react-icons/pi";
+
+import type {
+  ActivityStatus,
+  GetActivitiyByStatusResponse,
+} from "@/api/activity/api.model";
+import { formatDate } from "@/utils/date";
+
+type ActivityItem = GetActivitiyByStatusResponse["data"]["items"][number];
+
+interface ActivityAdminCardProps {
+  activity: ActivityItem;
+  status: ActivityStatus;
+  isMutating: boolean;
+  onApprove: () => void;
+  onReject: () => void;
+  onEnd: () => void;
+  onManage: () => void;
+  onDetail: () => void;
+}
+
+export default function ActivityAdminCard({
+  activity,
+  status,
+  isMutating,
+  onApprove,
+  onReject,
+  onEnd,
+  onManage,
+  onDetail,
+}: ActivityAdminCardProps) {
+  const leader = activity.leaders?.[0];
+
+  return (
+    <div className="border-gray-2 gap-md flex flex-col rounded-xl border bg-white p-4">
+      <div className="gap-xs flex items-center">
+        <Chip color="purple">
+          {activity.category === "PROJECT" ? "프로젝트" : "스터디"}
+        </Chip>
+        <Chip
+          color={
+            status === "WAITING"
+              ? "disabled"
+              : status === "PROGRESSING"
+                ? "green"
+                : "red"
+          }
+        >
+          {status === "WAITING"
+            ? "신청 대기"
+            : status === "PROGRESSING"
+              ? "진행 중"
+              : "종료"}
+        </Chip>
+      </div>
+
+      <button
+        type="button"
+        className="text-16-medium text-left text-black"
+        onClick={onDetail}
+      >
+        {activity.name}
+      </button>
+
+      <div className="gap-md text-12-regular text-gray-4 flex items-center">
+        {leader && (
+          <div className="gap-xs flex items-center">
+            <PiCrownSimpleFill />
+            {leader.name}
+          </div>
+        )}
+        {activity.participantCount > 0 && (
+          <div className="gap-xs flex items-center">
+            <GoPeople />
+            {activity.participantCount}
+          </div>
+        )}
+        <span>{formatDate(activity.createdAt)} 개설</span>
+      </div>
+
+      <div className="gap-sm flex flex-wrap justify-end">
+        {status === "WAITING" && (
+          <>
+            <Button
+              size="small"
+              color="outlineActive"
+              onClick={onReject}
+              disabled={isMutating}
+            >
+              거절
+            </Button>
+            <Button size="small" onClick={onApprove} disabled={isMutating}>
+              승인
+            </Button>
+          </>
+        )}
+        {status === "PROGRESSING" && (
+          <>
+            <Button size="small" color="outlineActive" onClick={onManage}>
+              신청자 관리
+            </Button>
+            <Button size="small" onClick={onEnd} disabled={isMutating}>
+              종료 처리
+            </Button>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/member/src/components/admin/AdminGuard.tsx
+++ b/apps/member/src/components/admin/AdminGuard.tsx
@@ -1,0 +1,32 @@
+import { useQuery } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+import { Navigate } from "react-router";
+
+import { userQueries } from "@/api/user/api.query";
+import { ROUTE } from "@/constants";
+
+interface AdminGuardProps {
+  children: ReactNode;
+  /** roleLevel 기준. 기본 2 (운영진 이상) */
+  minRoleLevel?: number;
+}
+
+export default function AdminGuard({
+  children,
+  minRoleLevel = 2,
+}: AdminGuardProps) {
+  const { data: userInfo, isLoading } = useQuery(
+    userQueries.getUserInfoQuery(),
+  );
+
+  if (isLoading) {
+    return null;
+  }
+
+  const roleLevel = userInfo?.data.roleLevel ?? 0;
+  if (roleLevel < minRoleLevel) {
+    return <Navigate to={ROUTE.HOME} replace />;
+  }
+
+  return <>{children}</>;
+}

--- a/apps/member/src/components/admin/AdminListState.tsx
+++ b/apps/member/src/components/admin/AdminListState.tsx
@@ -1,0 +1,38 @@
+interface AdminListStateProps {
+  isPending?: boolean;
+  isError?: boolean;
+  isEmpty?: boolean;
+  emptyMessage?: string;
+  errorMessage?: string;
+}
+
+export default function AdminListState({
+  isPending,
+  isError,
+  isEmpty,
+  emptyMessage = "표시할 항목이 없습니다.",
+  errorMessage = "목록을 불러오지 못했습니다.",
+}: AdminListStateProps) {
+  if (isPending) {
+    return (
+      <div className="text-14-regular text-gray-4 py-2xl text-center">
+        로딩 중...
+      </div>
+    );
+  }
+  if (isError) {
+    return (
+      <div className="text-14-regular text-red-5 py-2xl text-center">
+        {errorMessage}
+      </div>
+    );
+  }
+  if (isEmpty) {
+    return (
+      <div className="text-14-regular text-gray-4 py-2xl text-center">
+        {emptyMessage}
+      </div>
+    );
+  }
+  return null;
+}

--- a/apps/member/src/components/admin/AdminMenuCard.tsx
+++ b/apps/member/src/components/admin/AdminMenuCard.tsx
@@ -1,0 +1,37 @@
+import type { IconType } from "react-icons";
+import { IoChevronForward } from "react-icons/io5";
+import { Link } from "react-router";
+
+interface AdminMenuCardProps {
+  to: string;
+  label: string;
+  description?: string;
+  icon: IconType;
+}
+
+export default function AdminMenuCard({
+  to,
+  label,
+  description,
+  icon,
+}: AdminMenuCardProps) {
+  return (
+    <Link
+      to={to}
+      className="border-gray-2 px-gutter py-lg flex w-full items-center justify-between rounded-xl border bg-white"
+    >
+      <div className="gap-lg flex items-center">
+        <div className="bg-primary/10 flex size-10 items-center justify-center rounded-lg">
+          {icon({ className: "text-primary size-5" })}
+        </div>
+        <div className="flex flex-col">
+          <span className="text-16-medium text-black">{label}</span>
+          {description && (
+            <span className="text-12-regular text-gray-4">{description}</span>
+          )}
+        </div>
+      </div>
+      <IoChevronForward className="text-gray-4" />
+    </Link>
+  );
+}

--- a/apps/member/src/components/admin/AdminPagination.tsx
+++ b/apps/member/src/components/admin/AdminPagination.tsx
@@ -1,0 +1,39 @@
+import { Button } from "@clab/design-system";
+
+interface AdminPaginationProps {
+  currentPage: number;
+  totalPages: number;
+  onPageChange: (page: number) => void;
+}
+
+export default function AdminPagination({
+  currentPage,
+  totalPages,
+  onPageChange,
+}: AdminPaginationProps) {
+  if (totalPages <= 1) return null;
+
+  return (
+    <div className="gap-sm mt-lg flex items-center justify-center">
+      <Button
+        size="small"
+        color="outlineActive"
+        onClick={() => onPageChange(Math.max(0, currentPage - 1))}
+        disabled={currentPage <= 0}
+      >
+        이전
+      </Button>
+      <span className="text-12-medium text-gray-5 px-2">
+        {currentPage + 1} / {totalPages}
+      </span>
+      <Button
+        size="small"
+        color="outlineActive"
+        onClick={() => onPageChange(currentPage + 1)}
+        disabled={currentPage + 1 >= totalPages}
+      >
+        다음
+      </Button>
+    </div>
+  );
+}

--- a/apps/member/src/components/admin/AdminTabBadge.tsx
+++ b/apps/member/src/components/admin/AdminTabBadge.tsx
@@ -1,0 +1,23 @@
+import { cn } from "@/utils/cn";
+
+interface AdminTabBadgeProps {
+  count?: number;
+  className?: string;
+}
+
+export default function AdminTabBadge({
+  count,
+  className,
+}: AdminTabBadgeProps) {
+  if (typeof count !== "number" || count <= 0) return null;
+  return (
+    <span
+      className={cn(
+        "rounded-full bg-gray-100 px-2 text-[11px] font-semibold leading-[1.4] text-gray-400",
+        className,
+      )}
+    >
+      {count}
+    </span>
+  );
+}

--- a/apps/member/src/components/admin/ApplicationCard.tsx
+++ b/apps/member/src/components/admin/ApplicationCard.tsx
@@ -1,0 +1,51 @@
+import { Button, Chip } from "@clab/design-system";
+
+import type { ApplicationResponseDto } from "@/api/application";
+import { formatRelativeTime } from "@/utils/date";
+
+interface ApplicationCardProps {
+  application: ApplicationResponseDto;
+  isMutating: boolean;
+  onApprove: () => void;
+  onReject: () => void;
+}
+
+export default function ApplicationCard({
+  application,
+  isMutating,
+  onApprove,
+  onReject,
+}: ApplicationCardProps) {
+  return (
+    <div className="border-gray-2 gap-sm flex flex-col rounded-xl border bg-white p-4">
+      <div className="gap-xs flex flex-wrap items-center">
+        <Chip color="yellow">신청</Chip>
+        <span className="text-12-regular text-gray-4 ml-auto">
+          {formatRelativeTime(application.createdAt)}
+        </span>
+      </div>
+      <div className="gap-xs flex flex-col">
+        <p className="text-16-medium text-black">{application.name}</p>
+        <p className="text-12-regular text-gray-4">
+          학번 {application.studentId} · {application.department}
+        </p>
+        <p className="text-12-regular text-gray-4">
+          학적 {application.studentStatus ?? "-"} · {application.grade}학년
+        </p>
+      </div>
+      <div className="gap-sm flex justify-end">
+        <Button
+          size="small"
+          color="outlineActive"
+          onClick={onReject}
+          disabled={isMutating}
+        >
+          거절
+        </Button>
+        <Button size="small" onClick={onApprove} disabled={isMutating}>
+          승인
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/member/src/components/admin/ApplicationSection.tsx
+++ b/apps/member/src/components/admin/ApplicationSection.tsx
@@ -1,0 +1,88 @@
+import { Chip, Section } from "@clab/design-system";
+
+import type { ApplicationResponseDto } from "@/api/application";
+import type { OpenRecruitmentResponseDto } from "@/api/recruitment";
+
+import AdminListState from "./AdminListState";
+import AdminPagination from "./AdminPagination";
+import ApplicationCard from "./ApplicationCard";
+
+interface ApplicationSectionProps {
+  recruitments: OpenRecruitmentResponseDto[];
+  selectedRecruitmentId: number | null;
+  applications: ApplicationResponseDto[];
+  totalItems: number;
+  currentPage: number;
+  totalPages: number;
+  isPending: boolean;
+  isError: boolean;
+  isMutating: boolean;
+  onSelectRecruitment: (id: number) => void;
+  onApprove: (application: ApplicationResponseDto) => void;
+  onReject: (application: ApplicationResponseDto) => void;
+  onPageChange: (page: number) => void;
+}
+
+export default function ApplicationSection({
+  recruitments,
+  selectedRecruitmentId,
+  applications,
+  totalItems,
+  currentPage,
+  totalPages,
+  isPending,
+  isError,
+  isMutating,
+  onSelectRecruitment,
+  onApprove,
+  onReject,
+  onPageChange,
+}: ApplicationSectionProps) {
+  return (
+    <Section title={`가입 신청 ${totalItems}건`}>
+      {recruitments.length > 1 && (
+        <div className="gap-sm mb-lg flex flex-wrap">
+          {recruitments.map((recruitment) => (
+            <button
+              key={recruitment.id}
+              type="button"
+              onClick={() => onSelectRecruitment(recruitment.id)}
+            >
+              <Chip
+                color={
+                  selectedRecruitmentId === recruitment.id
+                    ? "primary"
+                    : "disabled"
+                }
+              >
+                {recruitment.title}
+              </Chip>
+            </button>
+          ))}
+        </div>
+      )}
+      <AdminListState
+        isPending={isPending}
+        isError={isError}
+        isEmpty={!isPending && applications.length === 0}
+        emptyMessage="처리 대기 중인 가입 신청이 없습니다."
+      />
+      <div className="gap-md flex flex-col">
+        {applications.map((application) => (
+          <ApplicationCard
+            key={`${application.recruitmentId}-${application.studentId}`}
+            application={application}
+            isMutating={isMutating}
+            onApprove={() => onApprove(application)}
+            onReject={() => onReject(application)}
+          />
+        ))}
+      </div>
+      <AdminPagination
+        currentPage={currentPage}
+        totalPages={totalPages}
+        onPageChange={onPageChange}
+      />
+    </Section>
+  );
+}

--- a/apps/member/src/components/admin/MemberCard.tsx
+++ b/apps/member/src/components/admin/MemberCard.tsx
@@ -1,0 +1,79 @@
+import { Button, Chip } from "@clab/design-system";
+
+import type {
+  MemberResponseDto,
+  MemberRoleInfoResponseDto,
+} from "@/api/member";
+import { formatDate } from "@/utils/date";
+import { formatStudentStatus, getRoleColor } from "@/utils/member";
+
+type AdminMemberItem = MemberResponseDto | MemberRoleInfoResponseDto;
+
+interface MemberCardProps {
+  member: AdminMemberItem;
+  isMutating: boolean;
+  onChangeRole: () => void;
+  onPasswordResend: () => void;
+  onDelete: () => void;
+}
+
+export default function MemberCard({
+  member,
+  isMutating,
+  onChangeRole,
+  onPasswordResend,
+  onDelete,
+}: MemberCardProps) {
+  return (
+    <div
+      className="border-gray-2 gap-sm flex flex-col rounded-xl border bg-white p-4"
+      onDoubleClick={onPasswordResend}
+    >
+      <div className="gap-xs flex flex-wrap items-center">
+        <Chip color={getRoleColor(member.role)}>{member.role}</Chip>
+        <span className="text-12-regular text-gray-4 ml-auto">
+          가입 {member.createdAt ? formatDate(member.createdAt) : "-"}
+        </span>
+      </div>
+      <div className="gap-xs flex flex-col">
+        <p className="text-16-medium text-black">{member.name}</p>
+        <p className="text-12-regular text-gray-4">
+          학번 : {member.id} / 학적 :{" "}
+          {formatStudentStatus(member.studentStatus)}
+        </p>
+        {member.department && (
+          <p className="text-12-regular text-gray-4">
+            {member.department}
+            {typeof member.grade === "number" ? ` · ${member.grade}학년` : ""}
+          </p>
+        )}
+      </div>
+      <div className="gap-sm flex flex-wrap justify-end">
+        <Button
+          size="small"
+          color="outlineActive"
+          onClick={onChangeRole}
+          disabled={isMutating}
+        >
+          권한 변경
+        </Button>
+        <Button
+          size="small"
+          color="outlineActive"
+          onClick={onPasswordResend}
+          disabled={isMutating}
+        >
+          비밀번호 재전송
+        </Button>
+        <Button
+          size="small"
+          color="outlineActive"
+          onClick={onDelete}
+          disabled={isMutating}
+        >
+          삭제
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/member/src/components/admin/RoleSelectModal.tsx
+++ b/apps/member/src/components/admin/RoleSelectModal.tsx
@@ -1,0 +1,52 @@
+import { Modal } from "@clab/design-system";
+
+import type {
+  MemberResponseDto,
+  MemberRole,
+  MemberRoleInfoResponseDto,
+} from "@/api/member";
+
+type AdminMemberItem = MemberResponseDto | MemberRoleInfoResponseDto;
+
+const MEMBER_ROLES = ["GUEST", "USER", "ADMIN", "SUPER"] as const;
+
+interface RoleSelectModalProps {
+  member: AdminMemberItem;
+  onClose: () => void;
+  onSelect: (role: MemberRole) => void;
+}
+
+export default function RoleSelectModal({
+  member,
+  onClose,
+  onSelect,
+}: RoleSelectModalProps) {
+  return (
+    <Modal isOpen onClose={onClose} title="권한 변경">
+      <div className="gap-lg flex flex-col">
+        <p className="text-14-regular text-black">
+          {member.name} 회원의 역할을 선택하세요.
+        </p>
+        <div className="gap-sm flex flex-col">
+          {MEMBER_ROLES.map((role) => (
+            <button
+              key={role}
+              type="button"
+              className="border-gray-2 flex items-center justify-between rounded-xl border px-4 py-3 text-left"
+              onClick={() => onSelect(role)}
+            >
+              <span className="text-14-medium text-black">{role}</span>
+              <span
+                className={
+                  member.role === role
+                    ? "border-primary bg-primary h-4 w-4 rounded-full border"
+                    : "border-gray-3 h-4 w-4 rounded-full border"
+                }
+              />
+            </button>
+          ))}
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/apps/member/src/components/admin/index.ts
+++ b/apps/member/src/components/admin/index.ts
@@ -1,0 +1,10 @@
+export { default as AdminGuard } from "./AdminGuard";
+export { default as AdminTabBadge } from "./AdminTabBadge";
+export { default as AdminMenuCard } from "./AdminMenuCard";
+export { default as AdminListState } from "./AdminListState";
+export { default as ActivityAdminCard } from "./ActivityAdminCard";
+export { default as AdminPagination } from "./AdminPagination";
+export { default as ApplicationCard } from "./ApplicationCard";
+export { default as ApplicationSection } from "./ApplicationSection";
+export { default as MemberCard } from "./MemberCard";
+export { default as RoleSelectModal } from "./RoleSelectModal";

--- a/apps/member/src/constants/route.ts
+++ b/apps/member/src/constants/route.ts
@@ -22,4 +22,11 @@ export const ROUTE = {
   SUPPORT: "/support",
   SUPPORT_WRITE: "/support/write",
   SUPPORT_DETAIL: (id: number) => `/support/${id}`,
+  ADMIN: "/admin",
+  ADMIN_SUPPORT: "/admin/support",
+  ADMIN_SUPPORT_DETAIL: (id: number) => `/admin/support/${id}`,
+  ADMIN_ACTIVITY: "/admin/activity",
+  ADMIN_LIBRARY: "/admin/library",
+  ADMIN_REPORT: "/admin/report",
+  ADMIN_MEMBER: "/admin/member",
 };

--- a/apps/member/src/constants/toast-messages.ts
+++ b/apps/member/src/constants/toast-messages.ts
@@ -87,4 +87,24 @@ export const TOAST_MESSAGES = {
     success: "답변이 삭제되었습니다.",
     error: "답변 삭제에 실패했습니다.",
   },
+  MEMBER_ROLE_UPDATE: {
+    success: "권한이 변경되었습니다.",
+    error: "권한 변경에 실패했습니다.",
+  },
+  MEMBER_DELETE: {
+    success: "회원이 삭제되었습니다.",
+    error: "회원 삭제에 실패했습니다.",
+  },
+  MEMBER_PASSWORD_RESEND: {
+    success: "비밀번호 재전송이 완료되었습니다.",
+    error: "비밀번호 재전송에 실패했습니다.",
+  },
+  APPLICATION_APPROVE: {
+    success: "가입 신청을 승인했습니다.",
+    error: "승인 처리에 실패했습니다.",
+  },
+  APPLICATION_REJECT: {
+    success: "가입 신청을 거절했습니다.",
+    error: "거절 처리에 실패했습니다.",
+  },
 } as const;

--- a/apps/member/src/pages/admin/AdminActivityPage.tsx
+++ b/apps/member/src/pages/admin/AdminActivityPage.tsx
@@ -1,0 +1,203 @@
+import { Header, Scrollable, Section, Tabs, Title } from "@clab/design-system";
+import { useMutation, useQueries, useQueryClient } from "@tanstack/react-query";
+import { useState } from "react";
+import { GoChevronLeft } from "react-icons/go";
+import { useNavigate, useSearchParams } from "react-router";
+
+import {
+  ActivityAdminCard,
+  AdminListState,
+  AdminTabBadge,
+} from "@/components/admin";
+import { ConfirmModal } from "@/components/common";
+
+import type {
+  ActivityStatus,
+  GetActivitiyByStatusResponse,
+} from "@/api/activity/api.model";
+import { activityQueries } from "@/api/activity/api.query";
+import { ROUTE } from "@/constants";
+
+const STATUS_TABS = [
+  { value: "WAITING", label: "신청" },
+  { value: "PROGRESSING", label: "진행" },
+  { value: "END", label: "종료" },
+] as const satisfies ReadonlyArray<{
+  value: ActivityStatus;
+  label: string;
+}>;
+
+type ActivityItem = GetActivitiyByStatusResponse["data"]["items"][number];
+
+type PendingAction = {
+  type: "approve" | "reject";
+  activityGroupId: number;
+  activityName: string;
+};
+
+export default function AdminActivityPage() {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const [searchParams] = useSearchParams();
+  const tab = (searchParams.get("tab") ?? "WAITING") as ActivityStatus;
+  const [pendingAction, setPendingAction] = useState<PendingAction | null>(
+    null,
+  );
+
+  const [waitingRes, progressingRes, endRes] = useQueries({
+    queries: STATUS_TABS.map((t) =>
+      activityQueries.getActivityByStatusQuery({
+        activityGroupStatus: t.value,
+        page: 0,
+        size: 50,
+      }),
+    ),
+  });
+
+  const counts: Record<ActivityStatus, number> = {
+    WAITING: waitingRes.data?.totalItems ?? 0,
+    PROGRESSING: progressingRes.data?.totalItems ?? 0,
+    END: endRes.data?.totalItems ?? 0,
+  };
+
+  const current =
+    tab === "WAITING"
+      ? waitingRes
+      : tab === "PROGRESSING"
+        ? progressingRes
+        : endRes;
+
+  const items: ActivityItem[] = current.data?.items ?? [];
+
+  const statusMutation = useMutation({
+    ...activityQueries.patchActivityStatusMutation,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: activityQueries.all });
+    },
+  });
+
+  const deleteMutation = useMutation({
+    ...activityQueries.deleteActivityMutation,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: activityQueries.all });
+    },
+  });
+
+  const handleApprove = (id: number) => {
+    statusMutation.mutate({
+      activityGroupId: id,
+      activityGroupStatus: "PROGRESSING",
+    });
+  };
+
+  const handleReject = (id: number) => {
+    deleteMutation.mutate(id);
+  };
+
+  const handleEnd = (id: number) => {
+    statusMutation.mutate({
+      activityGroupId: id,
+      activityGroupStatus: "END",
+    });
+  };
+
+  const handleConfirm = () => {
+    if (!pendingAction) return;
+    if (pendingAction.type === "approve") {
+      handleApprove(pendingAction.activityGroupId);
+    } else {
+      handleReject(pendingAction.activityGroupId);
+    }
+    setPendingAction(null);
+  };
+
+  return (
+    <>
+      <Header
+        left={
+          <button
+            type="button"
+            onClick={() => navigate(ROUTE.ADMIN)}
+            className="flex items-center gap-2"
+          >
+            <GoChevronLeft size={24} />
+            <Title>활동 관리</Title>
+          </button>
+        }
+        className="absolute left-0 right-0 top-0 bg-white"
+      />
+
+      <div className="pt-header-height h-full overflow-y-auto">
+        <Tabs>
+          {STATUS_TABS.map((t, idx) => (
+            <Tabs.Item
+              key={t.value}
+              label={t.label}
+              href={
+                idx === 0
+                  ? ROUTE.ADMIN_ACTIVITY
+                  : `${ROUTE.ADMIN_ACTIVITY}?tab=${t.value}`
+              }
+              endSlot={<AdminTabBadge count={counts[t.value]} />}
+            />
+          ))}
+        </Tabs>
+
+        <Scrollable className="px-gutter py-xl">
+          <Section
+            title={`${STATUS_TABS.find((t) => t.value === tab)?.label ?? ""} ${items.length}건`}
+          >
+            <AdminListState
+              isPending={current.isPending}
+              isError={current.isError}
+              isEmpty={!current.isPending && items.length === 0}
+              emptyMessage="해당 상태의 활동이 없습니다."
+            />
+
+            <div className="gap-md flex flex-col">
+              {items.map((activity) => (
+                <ActivityAdminCard
+                  key={activity.id}
+                  activity={activity}
+                  status={tab}
+                  isMutating={
+                    statusMutation.isPending || deleteMutation.isPending
+                  }
+                  onApprove={() =>
+                    setPendingAction({
+                      type: "approve",
+                      activityGroupId: activity.id,
+                      activityName: activity.name,
+                    })
+                  }
+                  onReject={() =>
+                    setPendingAction({
+                      type: "reject",
+                      activityGroupId: activity.id,
+                      activityName: activity.name,
+                    })
+                  }
+                  onEnd={() => handleEnd(activity.id)}
+                  onManage={() => navigate(ROUTE.ACTIVITY_MANAGE(activity.id))}
+                  onDetail={() => navigate(`${ROUTE.ACTIVITY}/${activity.id}`)}
+                />
+              ))}
+            </div>
+          </Section>
+        </Scrollable>
+      </div>
+
+      {pendingAction && (
+        <ConfirmModal
+          message={
+            pendingAction.type === "approve"
+              ? `"${pendingAction.activityName}" 활동을 승인하시겠습니까?`
+              : `"${pendingAction.activityName}" 활동을 거절(삭제)하시겠습니까?`
+          }
+          onClose={() => setPendingAction(null)}
+          onConfirm={handleConfirm}
+        />
+      )}
+    </>
+  );
+}

--- a/apps/member/src/pages/admin/AdminHomePage.tsx
+++ b/apps/member/src/pages/admin/AdminHomePage.tsx
@@ -1,0 +1,148 @@
+import { Header, Scrollable, Section, Title } from "@clab/design-system";
+import { useInfiniteQuery, useQueries, useQuery } from "@tanstack/react-query";
+import { BiCommentError } from "react-icons/bi";
+import { HiMiniSquare3Stack3D } from "react-icons/hi2";
+import { ImBubbles } from "react-icons/im";
+import { IoBook, IoPerson } from "react-icons/io5";
+
+import { AdminMenuCard } from "@/components/admin";
+import { BottomNavbar } from "@/components/menu";
+
+import { activityQueries } from "@/api/activity/api.query";
+import { accusationQueries } from "@/api/community/accusation";
+import { libraryQueries } from "@/api/library/api.query";
+import { supportQueries } from "@/api/support";
+import { ROUTE } from "@/constants";
+
+const PENDING_LOAN_PARAMS = {
+  status: "PENDING" as const,
+  page: 0,
+  size: 1,
+  sortBy: "borrowedAt" as const,
+  sortDirection: "desc" as const,
+};
+
+export default function AdminHomePage() {
+  const { data: supportPage } = useInfiniteQuery(
+    supportQueries.getSupportsInfiniteQuery(),
+  );
+  const supports = supportPage?.pages.flatMap((p) => p.data.items ?? []) ?? [];
+  const pendingSupportCount = supports.filter(
+    (s) => s.status === "PENDING",
+  ).length;
+
+  const [waitingActivityRes, progressingActivityRes] = useQueries({
+    queries: ["WAITING", "PROGRESSING"].map((status) =>
+      activityQueries.getActivityByStatusQuery({
+        activityGroupStatus: status as "WAITING" | "PROGRESSING",
+        page: 0,
+        size: 1,
+      }),
+    ),
+  });
+  const waitingActivityCount = waitingActivityRes.data?.totalItems ?? 0;
+  const progressingActivityCount = progressingActivityRes.data?.totalItems ?? 0;
+
+  const { data: pendingLoans } = useQuery(
+    libraryQueries.getBooksLoanConditionsQuery(PENDING_LOAN_PARAMS),
+  );
+  const { data: approvedLoans } = useQuery(
+    libraryQueries.getBooksLoanConditionsQuery({
+      ...PENDING_LOAN_PARAMS,
+      status: "APPROVED",
+    }),
+  );
+  const pendingLoanCount = pendingLoans?.totalItems ?? 0;
+  const loanedCount = approvedLoans?.totalItems ?? 0;
+
+  const { data: accusationsRes } = useQuery(
+    accusationQueries.getAccusationsQuery({
+      page: 0,
+      size: 1,
+      accuseStatus: "PENDING",
+    }),
+  );
+  const pendingAccusationCount =
+    accusationsRes?.ok && accusationsRes.data.data
+      ? accusationsRes.data.data.totalItems
+      : 0;
+
+  const totalPending =
+    pendingSupportCount +
+    waitingActivityCount +
+    pendingLoanCount +
+    pendingAccusationCount;
+
+  return (
+    <>
+      <Header
+        left={<Title>관리</Title>}
+        className="absolute left-0 right-0 top-0 bg-white"
+      />
+
+      <Scrollable className="pt-header-height pb-bottom-padding px-gutter gap-xl">
+        <Section className="py-xl">
+          <div className="bg-primary/5 border-primary/20 gap-md flex flex-col rounded-2xl border p-5">
+            <span className="text-14-medium text-primary">
+              {totalPending > 0
+                ? `${totalPending}건의 처리 대기 항목이 있어요`
+                : "처리 대기 항목이 없습니다"}
+            </span>
+            <div className="gap-sm flex flex-wrap">
+              <SummaryChip label="문의 미답변" count={pendingSupportCount} />
+              <SummaryChip label="활동 신청" count={waitingActivityCount} />
+              <SummaryChip label="대출 신청" count={pendingLoanCount} />
+              <SummaryChip label="신고" count={pendingAccusationCount} />
+            </div>
+          </div>
+        </Section>
+
+        <Section title="관리 메뉴" className="pb-xl">
+          <div className="gap-md flex flex-col">
+            <AdminMenuCard
+              to={ROUTE.ADMIN_MEMBER}
+              label="회원 관리"
+              description="가입 신청 · 권한"
+              icon={IoPerson}
+            />
+            <AdminMenuCard
+              to={ROUTE.ADMIN_LIBRARY}
+              label="도서 관리"
+              description={`대여 중 ${loanedCount} · 대출 신청 ${pendingLoanCount}`}
+              icon={IoBook}
+            />
+            <AdminMenuCard
+              to={ROUTE.ADMIN_ACTIVITY}
+              label="활동 관리"
+              description={`진행 ${progressingActivityCount} · 신청 ${waitingActivityCount}`}
+              icon={HiMiniSquare3Stack3D}
+            />
+            <AdminMenuCard
+              to={ROUTE.ADMIN_REPORT}
+              label="신고 관리"
+              description={`신고 ${pendingAccusationCount}건`}
+              icon={ImBubbles}
+            />
+            <AdminMenuCard
+              to={ROUTE.ADMIN_SUPPORT}
+              label="문의 관리"
+              description={`미답변 ${pendingSupportCount}건`}
+              icon={BiCommentError}
+            />
+          </div>
+        </Section>
+      </Scrollable>
+
+      <BottomNavbar />
+    </>
+  );
+}
+
+function SummaryChip({ label, count }: { label: string; count: number }) {
+  return (
+    <div className="gap-xs flex items-center rounded-full border border-gray-100 bg-white px-3 py-1.5">
+      <span className="text-12-regular text-gray-5">{label}</span>
+      <span className="text-12-medium text-primary">{count}</span>
+    </div>
+  );
+}

--- a/apps/member/src/pages/admin/AdminLibraryPage.tsx
+++ b/apps/member/src/pages/admin/AdminLibraryPage.tsx
@@ -1,0 +1,247 @@
+import {
+  Chip,
+  Header,
+  Scrollable,
+  Section,
+  Tabs,
+  Title,
+} from "@clab/design-system";
+import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
+import dayjs from "dayjs";
+import { useMemo, useState } from "react";
+import { GoChevronLeft } from "react-icons/go";
+import { useNavigate, useSearchParams } from "react-router";
+
+import { useDebounce } from "@/model/common/useDebounce";
+import { useInfiniteScroll } from "@/model/common/useInfiniteScroll";
+
+import { AdminListState, AdminTabBadge } from "@/components/admin";
+import { LibraryBookList, LibrarySearchBar } from "@/components/library";
+
+import type {
+  BookLoanStatus,
+  getBooksLoanConditionsResponse,
+} from "@/api/library/api.model";
+import { libraryQueries } from "@/api/library/api.query";
+import { ROUTE } from "@/constants";
+
+type LibraryTab = "LOANED" | "OVERDUE" | "BOOKS";
+
+type LoanItem = getBooksLoanConditionsResponse["data"]["items"][number];
+
+const PAGE_SIZE = 20;
+
+export default function AdminLibraryPage() {
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const tab = (searchParams.get("tab") ?? "LOANED") as LibraryTab;
+  const [keyword, setKeyword] = useState("");
+  const debouncedKeyword = useDebounce(keyword, 400);
+
+  const loanedQuery = useQuery(
+    libraryQueries.getBooksLoanConditionsQuery({
+      status: "APPROVED" as BookLoanStatus,
+      page: 0,
+      size: PAGE_SIZE,
+      sortBy: "borrowedAt",
+      sortDirection: "desc",
+    }),
+  );
+
+  const allBookLoans = useMemo(
+    () => loanedQuery.data?.items ?? [],
+    [loanedQuery.data?.items],
+  );
+  const overdueLoans = useMemo(
+    () =>
+      allBookLoans.filter(
+        (item) => item.dueDate && dayjs(item.dueDate).isBefore(dayjs(), "day"),
+      ),
+    [allBookLoans],
+  );
+
+  const booksRequest = {
+    title: debouncedKeyword.trim() || undefined,
+  };
+
+  const {
+    data: booksData,
+    hasNextPage,
+    fetchNextPage,
+    isFetchingNextPage,
+    isPending: booksPending,
+    isError: booksError,
+  } = useInfiniteQuery({
+    ...libraryQueries.getBooksInfiniteQuery(booksRequest),
+    enabled: tab === "BOOKS",
+  });
+
+  const { scrollRef, bottomSentinelRef } = useInfiniteScroll({
+    hasNextPage: hasNextPage ?? false,
+    isFetchingNextPage,
+    fetchNextPage,
+  });
+
+  const books = useMemo(
+    () => booksData?.pages.flatMap((p) => p.data.items ?? []) ?? [],
+    [booksData],
+  );
+
+  return (
+    <>
+      <Header
+        left={
+          <button
+            type="button"
+            onClick={() => navigate(ROUTE.ADMIN)}
+            className="flex items-center gap-2"
+          >
+            <GoChevronLeft size={24} />
+            <Title>도서 관리</Title>
+          </button>
+        }
+        className="absolute left-0 right-0 top-0 bg-white"
+      />
+
+      <div ref={scrollRef} className="pt-header-height h-full overflow-y-auto">
+        <Tabs>
+          <Tabs.Item
+            label="대여"
+            href={ROUTE.ADMIN_LIBRARY}
+            endSlot={<AdminTabBadge count={allBookLoans.length} />}
+          />
+          <Tabs.Item
+            label="연체"
+            href={`${ROUTE.ADMIN_LIBRARY}?tab=OVERDUE`}
+            endSlot={<AdminTabBadge count={overdueLoans.length} />}
+          />
+          <Tabs.Item
+            label="도서"
+            href={`${ROUTE.ADMIN_LIBRARY}?tab=BOOKS`}
+            endSlot={
+              <AdminTabBadge count={booksData?.pages[0]?.data.totalItems} />
+            }
+          />
+        </Tabs>
+
+        {tab === "LOANED" && (
+          <Scrollable className="px-gutter py-xl">
+            <Section title={`대여 중 ${allBookLoans.length}권`}>
+              <AdminListState
+                isPending={loanedQuery.isPending}
+                isError={loanedQuery.isError}
+                isEmpty={!loanedQuery.isPending && allBookLoans.length === 0}
+                emptyMessage="대여 중인 도서가 없습니다."
+              />
+              <div className="gap-md flex flex-col">
+                {allBookLoans.map((loan) => (
+                  <LoanCard
+                    key={loan.bookLoanRecordId}
+                    loan={loan}
+                    onClickBook={() =>
+                      navigate(`${ROUTE.LIBRARY}/${loan.bookId}`)
+                    }
+                  />
+                ))}
+              </div>
+            </Section>
+          </Scrollable>
+        )}
+
+        {tab === "OVERDUE" && (
+          <Scrollable className="px-gutter py-xl">
+            <Section title={`연체 ${overdueLoans.length}건`}>
+              {overdueLoans.length > 0 && (
+                <div className="rounded-lg bg-red-50 px-4 py-3 text-[13px] text-red-600">
+                  {overdueLoans.length}권의 연체 도서가 있어요.
+                </div>
+              )}
+              <AdminListState
+                isPending={loanedQuery.isPending}
+                isError={loanedQuery.isError}
+                isEmpty={!loanedQuery.isPending && overdueLoans.length === 0}
+                emptyMessage="연체 도서가 없습니다."
+              />
+              <div className="gap-md flex flex-col">
+                {overdueLoans.map((loan) => (
+                  <LoanCard
+                    key={loan.bookLoanRecordId}
+                    loan={loan}
+                    overdue
+                    onClickBook={() =>
+                      navigate(`${ROUTE.LIBRARY}/${loan.bookId}`)
+                    }
+                  />
+                ))}
+              </div>
+            </Section>
+          </Scrollable>
+        )}
+
+        {tab === "BOOKS" && (
+          <Scrollable className="py-xl gap-lg">
+            <LibrarySearchBar value={keyword} onChange={setKeyword} />
+            <Section
+              title={`전체 ${booksData?.pages[0]?.data.totalItems ?? 0}권`}
+              className="px-gutter"
+            >
+              <AdminListState
+                isPending={booksPending}
+                isError={booksError}
+                isEmpty={!booksPending && books.length === 0}
+                emptyMessage="등록된 도서가 없습니다."
+              />
+              {books.length > 0 && (
+                <LibraryBookList
+                  books={books}
+                  bottomSentinelRef={bottomSentinelRef}
+                />
+              )}
+            </Section>
+          </Scrollable>
+        )}
+      </div>
+    </>
+  );
+}
+
+interface LoanCardProps {
+  loan: LoanItem;
+  overdue?: boolean;
+  onClickBook: () => void;
+}
+
+function LoanCard({ loan, overdue, onClickBook }: LoanCardProps) {
+  const due = loan.dueDate ? dayjs(loan.dueDate) : null;
+  const overdueDays = due ? dayjs().diff(due, "day") : 0;
+
+  return (
+    <div className="border-gray-2 gap-sm flex flex-col rounded-xl border bg-white p-4">
+      <div className="gap-xs flex items-center">
+        <Chip color={overdue ? "red" : "yellow"}>
+          {overdue ? "연체" : "대여중"}
+        </Chip>
+        {due && (
+          <span
+            className={
+              overdue
+                ? "text-12-medium text-red-500"
+                : "text-gray-4 text-12-regular"
+            }
+          >
+            마감 {due.format("YYYY-MM-DD")}
+            {overdue ? ` (${overdueDays}일 경과)` : ""}
+          </span>
+        )}
+      </div>
+      <button
+        type="button"
+        className="text-16-medium text-left text-black"
+        onClick={onClickBook}
+      >
+        {loan.bookTitle}
+      </button>
+      <div className="text-12-regular text-gray-4">{loan.borrowerName}</div>
+    </div>
+  );
+}

--- a/apps/member/src/pages/admin/AdminMemberPage.tsx
+++ b/apps/member/src/pages/admin/AdminMemberPage.tsx
@@ -1,0 +1,379 @@
+import {
+  Chip,
+  Header,
+  Scrollable,
+  Section,
+  Tabs,
+  Title,
+} from "@clab/design-system";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMemo, useState } from "react";
+import { GoChevronLeft } from "react-icons/go";
+import { useNavigate, useSearchParams } from "react-router";
+
+import { useDebounce } from "@/model/common/useDebounce";
+
+import {
+  AdminListState,
+  AdminPagination,
+  AdminTabBadge,
+  ApplicationSection,
+  MemberCard,
+  RoleSelectModal,
+} from "@/components/admin";
+import { ConfirmModal } from "@/components/common";
+
+import { applicationKeys, applicationQueries } from "@/api/application";
+import { memberKeys, memberQueries } from "@/api/member";
+import type {
+  MemberResponseDto,
+  MemberRole,
+  MemberRoleInfoResponseDto,
+} from "@/api/member";
+import { recruitmentQueries } from "@/api/recruitment";
+import { ROUTE } from "@/constants";
+import { getConfirmMessage } from "@/utils/admin";
+import type { AdminMemberPendingAction } from "@/utils/admin";
+
+type AdminMemberTab = "MEMBERS" | "APPLICATIONS";
+type MemberRoleFilter = "ALL" | Extract<MemberRole, "ADMIN" | "SUPER">;
+type AdminMemberItem = MemberResponseDto | MemberRoleInfoResponseDto;
+
+type PendingAction = AdminMemberPendingAction;
+
+const PAGE_SIZE = 20;
+const MEMBER_FILTERS = [
+  { value: "ALL", label: "전체" },
+  { value: "ADMIN", label: "ADMIN" },
+  { value: "SUPER", label: "SUPER" },
+] as const satisfies ReadonlyArray<{ value: MemberRoleFilter; label: string }>;
+
+export default function AdminMemberPage() {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const [searchParams] = useSearchParams();
+  const tab = (searchParams.get("tab") ?? "MEMBERS") as AdminMemberTab;
+  const [keyword, setKeyword] = useState("");
+  const debouncedKeyword = useDebounce(keyword, 400);
+  const [memberFilter, setMemberFilter] = useState<MemberRoleFilter>("ALL");
+  const [memberPage, setMemberPage] = useState(0);
+  const [applicationPage, setApplicationPage] = useState(0);
+  const [selectedRecruitmentId, setSelectedRecruitmentId] = useState<
+    number | null
+  >(null);
+  const [roleModalMember, setRoleModalMember] =
+    useState<AdminMemberItem | null>(null);
+  const [pendingAction, setPendingAction] = useState<PendingAction | null>(
+    null,
+  );
+
+  const memberSearchParams = useMemo(() => {
+    const text = debouncedKeyword.trim();
+    if (!text) return {};
+    return /^\d+$/.test(text) ? { id: text } : { name: text };
+  }, [debouncedKeyword]);
+
+  const memberListQuery = useQuery({
+    ...memberQueries.getMembersQuery({
+      ...memberSearchParams,
+      page: memberPage,
+      size: PAGE_SIZE,
+    }),
+    enabled: tab === "MEMBERS" && memberFilter === "ALL",
+  });
+
+  const memberByRoleQuery = useQuery({
+    ...memberQueries.getMembersByRoleQuery({
+      role: memberFilter === "ALL" ? undefined : memberFilter,
+      memberId: memberSearchParams.id,
+      memberName: memberSearchParams.name,
+      page: memberPage,
+      size: PAGE_SIZE,
+    }),
+    enabled: tab === "MEMBERS" && memberFilter !== "ALL",
+  });
+
+  const currentMemberQuery =
+    memberFilter === "ALL" ? memberListQuery : memberByRoleQuery;
+  const memberPageData =
+    currentMemberQuery.data?.ok && currentMemberQuery.data.data.data
+      ? currentMemberQuery.data.data.data
+      : undefined;
+  const members: AdminMemberItem[] = memberPageData?.items ?? [];
+
+  const openRecruitmentsQuery = useQuery(
+    recruitmentQueries.getOpenRecruitmentsQuery(),
+  );
+  const openRecruitments = useMemo(
+    () =>
+      openRecruitmentsQuery.data?.ok && openRecruitmentsQuery.data.data.data
+        ? openRecruitmentsQuery.data.data.data
+        : [],
+    [openRecruitmentsQuery.data],
+  );
+
+  const effectiveRecruitmentId =
+    selectedRecruitmentId ?? openRecruitments[0]?.id ?? null;
+  const badgeRecruitmentId = openRecruitments[0]?.id;
+  const applicationBadgeQuery = useQuery({
+    ...applicationQueries.getApplicationConditionsQuery({
+      recruitmentId: badgeRecruitmentId,
+      isPass: false,
+      page: 0,
+      size: 1,
+    }),
+    enabled: typeof badgeRecruitmentId === "number",
+  });
+  const applicationBadgeCount =
+    applicationBadgeQuery.data?.ok && applicationBadgeQuery.data.data.data
+      ? applicationBadgeQuery.data.data.data.totalItems
+      : 0;
+
+  const applicationQuery = useQuery({
+    ...applicationQueries.getApplicationConditionsQuery({
+      recruitmentId: effectiveRecruitmentId ?? undefined,
+      isPass: false,
+      page: applicationPage,
+      size: PAGE_SIZE,
+    }),
+    enabled: tab === "APPLICATIONS" && effectiveRecruitmentId !== null,
+  });
+  const applicationPageData =
+    applicationQuery.data?.ok && applicationQuery.data.data.data
+      ? applicationQuery.data.data.data
+      : undefined;
+  const applications = applicationPageData?.items ?? [];
+
+  const roleMutation = useMutation({
+    ...memberQueries.patchMemberRoleMutation,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: memberKeys.all });
+    },
+  });
+  const passwordMutation = useMutation(
+    memberQueries.postPasswordResendMutation,
+  );
+  const deleteMutation = useMutation({
+    ...memberQueries.deleteMemberMutation,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: memberKeys.all });
+    },
+  });
+  const approveMutation = useMutation({
+    ...applicationQueries.patchApplicationApproveMutation,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: applicationKeys.all });
+    },
+  });
+  const rejectMutation = useMutation({
+    ...applicationQueries.patchApplicationRejectMutation,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: applicationKeys.all });
+    },
+  });
+
+  const isMemberMutating =
+    roleMutation.isPending ||
+    passwordMutation.isPending ||
+    deleteMutation.isPending;
+  const isApplicationMutating =
+    approveMutation.isPending || rejectMutation.isPending;
+
+  const handleConfirm = () => {
+    if (!pendingAction) return;
+
+    if (pendingAction.type === "role") {
+      roleMutation.mutate({
+        memberId: pendingAction.memberId,
+        body: { role: pendingAction.role },
+      });
+    }
+    if (pendingAction.type === "password") {
+      passwordMutation.mutate(pendingAction.memberId);
+    }
+    if (pendingAction.type === "delete") {
+      deleteMutation.mutate(pendingAction.memberId);
+    }
+    if (pendingAction.type === "approve") {
+      approveMutation.mutate({
+        recruitmentId: pendingAction.recruitmentId,
+        studentId: pendingAction.studentId,
+      });
+    }
+    if (pendingAction.type === "reject") {
+      rejectMutation.mutate({
+        recruitmentId: pendingAction.recruitmentId,
+        studentId: pendingAction.studentId,
+      });
+    }
+    setPendingAction(null);
+  };
+
+  return (
+    <>
+      <Header
+        left={
+          <button
+            type="button"
+            onClick={() => navigate(ROUTE.ADMIN)}
+            className="flex items-center gap-2"
+          >
+            <GoChevronLeft size={24} />
+            <Title>회원 관리</Title>
+          </button>
+        }
+        className="absolute left-0 right-0 top-0 bg-white"
+      />
+
+      <div className="pt-header-height h-full overflow-y-auto">
+        <Tabs>
+          <Tabs.Item label="회원" href={ROUTE.ADMIN_MEMBER} />
+          <Tabs.Item
+            label="신청"
+            href={`${ROUTE.ADMIN_MEMBER}?tab=APPLICATIONS`}
+            endSlot={<AdminTabBadge count={applicationBadgeCount} />}
+          />
+        </Tabs>
+
+        {tab === "APPLICATIONS" ? (
+          <Scrollable className="px-gutter py-xl">
+            <ApplicationSection
+              recruitments={openRecruitments}
+              selectedRecruitmentId={effectiveRecruitmentId}
+              applications={applications}
+              totalItems={applicationPageData?.totalItems ?? 0}
+              currentPage={applicationPage}
+              totalPages={applicationPageData?.totalPages ?? 0}
+              isPending={
+                openRecruitmentsQuery.isPending || applicationQuery.isPending
+              }
+              isError={
+                openRecruitmentsQuery.isError || applicationQuery.isError
+              }
+              isMutating={isApplicationMutating}
+              onSelectRecruitment={(id) => {
+                setSelectedRecruitmentId(id);
+                setApplicationPage(0);
+              }}
+              onApprove={(application) =>
+                setPendingAction({
+                  type: "approve",
+                  recruitmentId: application.recruitmentId,
+                  studentId: application.studentId,
+                  name: application.name,
+                })
+              }
+              onReject={(application) =>
+                setPendingAction({
+                  type: "reject",
+                  recruitmentId: application.recruitmentId,
+                  studentId: application.studentId,
+                  name: application.name,
+                })
+              }
+              onPageChange={setApplicationPage}
+            />
+          </Scrollable>
+        ) : (
+          <Scrollable className="px-gutter gap-lg py-xl">
+            <Section>
+              <div className="gap-md flex flex-col">
+                <input
+                  value={keyword}
+                  onChange={(event) => {
+                    setKeyword(event.target.value);
+                    setMemberPage(0);
+                  }}
+                  placeholder="학번 또는 이름 검색"
+                  className="border-gray-2 text-14-regular placeholder:text-gray-4 focus:border-primary rounded-xl border bg-white px-4 py-3 text-black outline-none"
+                />
+              </div>
+            </Section>
+            <Section title={`회원 ${memberPageData?.totalItems ?? 0}명`}>
+              <div className="gap-sm flex flex-wrap items-center">
+                {MEMBER_FILTERS.map((item) => (
+                  <button
+                    key={item.value}
+                    type="button"
+                    onClick={() => {
+                      setMemberFilter(item.value);
+                      setMemberPage(0);
+                    }}
+                  >
+                    <Chip
+                      color={
+                        memberFilter === item.value ? "primary" : "disabled"
+                      }
+                    >
+                      {item.label}
+                    </Chip>
+                  </button>
+                ))}
+              </div>
+              <AdminListState
+                isPending={currentMemberQuery.isPending}
+                isError={currentMemberQuery.isError}
+                isEmpty={!currentMemberQuery.isPending && members.length === 0}
+                emptyMessage="조건에 맞는 회원이 없습니다."
+              />
+              <div className="gap-md flex flex-col">
+                {members.map((member) => (
+                  <MemberCard
+                    key={member.id}
+                    member={member}
+                    isMutating={isMemberMutating}
+                    onChangeRole={() => setRoleModalMember(member)}
+                    onPasswordResend={() =>
+                      setPendingAction({
+                        type: "password",
+                        memberId: member.id,
+                        name: member.name,
+                      })
+                    }
+                    onDelete={() =>
+                      setPendingAction({
+                        type: "delete",
+                        memberId: member.id,
+                        name: member.name,
+                      })
+                    }
+                  />
+                ))}
+              </div>
+              <AdminPagination
+                currentPage={memberPage}
+                totalPages={memberPageData?.totalPages ?? 0}
+                onPageChange={setMemberPage}
+              />
+            </Section>
+          </Scrollable>
+        )}
+      </div>
+
+      {roleModalMember && (
+        <RoleSelectModal
+          member={roleModalMember}
+          onClose={() => setRoleModalMember(null)}
+          onSelect={(role) => {
+            setRoleModalMember(null);
+            setPendingAction({
+              type: "role",
+              memberId: roleModalMember.id,
+              name: roleModalMember.name,
+              role,
+            });
+          }}
+        />
+      )}
+
+      {pendingAction && (
+        <ConfirmModal
+          message={getConfirmMessage(pendingAction)}
+          onClose={() => setPendingAction(null)}
+          onConfirm={handleConfirm}
+          confirmLabel={pendingAction.type === "delete" ? "삭제" : "확인"}
+        />
+      )}
+    </>
+  );
+}

--- a/apps/member/src/pages/admin/AdminReportPage.tsx
+++ b/apps/member/src/pages/admin/AdminReportPage.tsx
@@ -1,0 +1,259 @@
+import {
+  Button,
+  Chip,
+  Header,
+  Scrollable,
+  Section,
+  Title,
+} from "@clab/design-system";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useState } from "react";
+import { GoChevronLeft } from "react-icons/go";
+import { useNavigate } from "react-router";
+
+import { AdminListState } from "@/components/admin";
+import { ConfirmModal } from "@/components/common";
+
+import { accusationQueries } from "@/api/community/accusation";
+import type {
+  AccuseResponseDto,
+  TargetType,
+} from "@/api/community/accusation/api.model";
+import { boardQueries } from "@/api/community/board/api.query";
+import { commentQueries } from "@/api/community/comment";
+import { ROUTE } from "@/constants";
+import { formatRelativeTime } from "@/utils/date";
+
+type PendingAction =
+  | {
+      type: "keep";
+      targetType: TargetType;
+      targetId: number;
+    }
+  | {
+      type: "delete";
+      targetType: TargetType;
+      targetId: number;
+    };
+
+export default function AdminReportPage() {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const [pending, setPending] = useState<PendingAction | null>(null);
+
+  const {
+    data: pendingResp,
+    isPending,
+    isError,
+  } = useQuery(
+    accusationQueries.getAccusationsQuery({
+      page: 0,
+      size: 50,
+      accuseStatus: "PENDING",
+    }),
+  );
+
+  const items: AccuseResponseDto[] =
+    pendingResp?.ok && pendingResp.data.data ? pendingResp.data.data.items : [];
+
+  const patchAccusation = useMutation({
+    ...accusationQueries.patchAccusationStatusMutation,
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["community", "accusations"],
+      });
+    },
+  });
+
+  const deleteBoard = useMutation({
+    ...boardQueries.deleteBoardMutation,
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["community", "accusations"],
+      });
+    },
+  });
+
+  const deleteComment = useMutation({
+    ...commentQueries.deleteCommentMutation,
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["community", "accusations"],
+      });
+    },
+  });
+
+  const handleConfirm = () => {
+    if (!pending) return;
+
+    if (pending.type === "keep") {
+      patchAccusation.mutate({
+        targetType: pending.targetType,
+        targetId: pending.targetId,
+        accuseStatus: "REJECTED",
+      });
+      setPending(null);
+      return;
+    }
+
+    const onTargetDeleted = () =>
+      patchAccusation.mutate({
+        targetType: pending.targetType,
+        targetId: pending.targetId,
+        accuseStatus: "APPROVED",
+      });
+
+    if (pending.targetType === "BOARD") {
+      deleteBoard.mutate(pending.targetId, { onSuccess: onTargetDeleted });
+    } else {
+      deleteComment.mutate(pending.targetId, { onSuccess: onTargetDeleted });
+    }
+    setPending(null);
+  };
+
+  return (
+    <>
+      <Header
+        left={
+          <button
+            type="button"
+            onClick={() => navigate(ROUTE.ADMIN)}
+            className="flex items-center gap-2"
+          >
+            <GoChevronLeft size={24} />
+            <Title>신고 관리</Title>
+          </button>
+        }
+        className="absolute left-0 right-0 top-0 bg-white"
+      />
+
+      <Scrollable className="pt-header-height px-gutter py-xl">
+        <Section title={`신고 ${items.length}건`}>
+          <AdminListState
+            isPending={isPending}
+            isError={isError}
+            isEmpty={!isPending && items.length === 0}
+            emptyMessage="처리 대기 중인 신고가 없습니다."
+          />
+
+          <div className="gap-md flex flex-col">
+            {items.map((item) => (
+              <AccusationCard
+                key={`${item.targetType}-${item.targetId}`}
+                item={item}
+                isMutating={
+                  patchAccusation.isPending ||
+                  deleteBoard.isPending ||
+                  deleteComment.isPending
+                }
+                onKeep={() =>
+                  setPending({
+                    type: "keep",
+                    targetType: item.targetType,
+                    targetId: item.targetId,
+                  })
+                }
+                onDelete={() =>
+                  setPending({
+                    type: "delete",
+                    targetType: item.targetType,
+                    targetId: item.targetId,
+                  })
+                }
+                onView={() => {
+                  if (item.targetType === "BOARD") {
+                    navigate(`${ROUTE.COMMUNITY}/${item.targetId}`);
+                  }
+                  // COMMENT 신고는 AccuseResponseDto에 parent boardId가 없어
+                  // 댓글 위치로 navigate 불가. BE에 parentBoardId 보강되면 연결.
+                }}
+              />
+            ))}
+          </div>
+        </Section>
+      </Scrollable>
+
+      {pending && (
+        <ConfirmModal
+          message={getConfirmMessage(pending)}
+          onClose={() => setPending(null)}
+          onConfirm={handleConfirm}
+        />
+      )}
+    </>
+  );
+}
+
+function getConfirmMessage(action: PendingAction) {
+  const target = action.targetType === "BOARD" ? "게시글" : "댓글";
+  if (action.type === "keep") {
+    return `신고를 기각하시겠습니까? (${target}은(는) 그대로 유지됩니다.)`;
+  }
+  return `신고를 승인하고 ${target}을(를) 삭제하시겠습니까?`;
+}
+
+interface AccusationCardProps {
+  item: AccuseResponseDto;
+  isMutating: boolean;
+  onKeep: () => void;
+  onDelete: () => void;
+  onView: () => void;
+}
+
+function AccusationCard({
+  item,
+  isMutating,
+  onKeep,
+  onDelete,
+  onView,
+}: AccusationCardProps) {
+  return (
+    <div className="border-gray-2 gap-sm flex flex-col rounded-xl border bg-white p-4">
+      <div className="gap-xs flex flex-wrap items-center">
+        <Chip color="purple">
+          {item.targetType === "BOARD" ? "게시글" : "댓글"}
+        </Chip>
+        <Chip color="red">신고됨</Chip>
+        <span className="text-12-regular text-gray-4 ml-auto">
+          {formatRelativeTime(item.createdAt)}
+        </span>
+      </div>
+
+      <button
+        type="button"
+        className="text-16-medium text-left text-black"
+        onClick={onView}
+      >
+        {item.reason || "(사유 없음)"}
+      </button>
+
+      <div className="text-12-regular text-gray-4">
+        신고 {item.accuseCount}회
+        {item.members.length > 0 && (
+          <>
+            {" · "}
+            {item.members
+              .slice(0, 3)
+              .map((m) => m.memberName)
+              .join(", ")}
+            {item.members.length > 3 ? " 외" : ""}
+          </>
+        )}
+      </div>
+
+      <div className="gap-sm flex justify-end">
+        <Button
+          size="small"
+          color="outlineActive"
+          onClick={onKeep}
+          disabled={isMutating}
+        >
+          유지
+        </Button>
+        <Button size="small" onClick={onDelete} disabled={isMutating}>
+          삭제
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/member/src/pages/admin/AdminSupportPage.tsx
+++ b/apps/member/src/pages/admin/AdminSupportPage.tsx
@@ -1,0 +1,111 @@
+import { Header, Scrollable, Section, Tabs, Title } from "@clab/design-system";
+import { useInfiniteQuery } from "@tanstack/react-query";
+import { useMemo } from "react";
+import { GoChevronLeft } from "react-icons/go";
+import { useNavigate, useSearchParams } from "react-router";
+
+import { useInfiniteScroll } from "@/model/common/useInfiniteScroll";
+
+import { AdminListState, AdminTabBadge } from "@/components/admin";
+import { SupportItem } from "@/components/support";
+
+import { supportQueries } from "@/api/support";
+import { ROUTE } from "@/constants";
+
+type SupportTab = "PENDING" | "ALL";
+
+export default function AdminSupportPage() {
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const tab = (searchParams.get("tab") ?? "PENDING") as SupportTab;
+
+  const {
+    data,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+    isPending,
+    isError,
+  } = useInfiniteQuery(supportQueries.getSupportsInfiniteQuery());
+
+  const { scrollRef, bottomSentinelRef } = useInfiniteScroll({
+    hasNextPage: hasNextPage ?? false,
+    isFetchingNextPage,
+    fetchNextPage,
+  });
+
+  const allSupports = useMemo(
+    () => data?.pages.flatMap((p) => p.data.items ?? []) ?? [],
+    [data],
+  );
+  const pendingSupports = useMemo(
+    () => allSupports.filter((s) => s.status === "PENDING"),
+    [allSupports],
+  );
+
+  const visible = tab === "PENDING" ? pendingSupports : allSupports;
+
+  return (
+    <>
+      <Header
+        left={
+          <button
+            type="button"
+            onClick={() => navigate(ROUTE.ADMIN)}
+            className="flex items-center gap-2"
+          >
+            <GoChevronLeft size={24} />
+            <Title>문의 관리</Title>
+          </button>
+        }
+        className="absolute left-0 right-0 top-0 bg-white"
+      />
+
+      <div ref={scrollRef} className="pt-header-height h-full overflow-y-auto">
+        <Tabs>
+          <Tabs.Item
+            label="미답변"
+            href={ROUTE.ADMIN_SUPPORT}
+            endSlot={<AdminTabBadge count={pendingSupports.length} />}
+          />
+          <Tabs.Item label="전체" href={`${ROUTE.ADMIN_SUPPORT}?tab=ALL`} />
+        </Tabs>
+
+        <Scrollable className="px-gutter py-xl">
+          <Section
+            title={
+              tab === "PENDING"
+                ? `미답변 ${pendingSupports.length}건`
+                : `전체 ${allSupports.length}건`
+            }
+          >
+            <AdminListState
+              isPending={isPending}
+              isError={isError}
+              isEmpty={visible.length === 0 && !isPending && !isError}
+              emptyMessage={
+                tab === "PENDING"
+                  ? "미답변 문의가 없습니다."
+                  : "등록된 문의가 없습니다."
+              }
+            />
+
+            {visible.length > 0 && (
+              <Section.List>
+                {visible.map((support) => (
+                  <SupportItem
+                    key={support.id}
+                    support={support}
+                    onSelect={(id) => navigate(ROUTE.ADMIN_SUPPORT_DETAIL(id))}
+                  />
+                ))}
+              </Section.List>
+            )}
+
+            <div ref={bottomSentinelRef} />
+          </Section>
+        </Scrollable>
+      </div>
+    </>
+  );
+}

--- a/apps/member/src/pages/admin/index.ts
+++ b/apps/member/src/pages/admin/index.ts
@@ -1,0 +1,6 @@
+export { default as AdminHomePage } from "./AdminHomePage";
+export { default as AdminSupportPage } from "./AdminSupportPage";
+export { default as AdminActivityPage } from "./AdminActivityPage";
+export { default as AdminLibraryPage } from "./AdminLibraryPage";
+export { default as AdminReportPage } from "./AdminReportPage";
+export { default as AdminMemberPage } from "./AdminMemberPage";

--- a/apps/member/src/pages/index.ts
+++ b/apps/member/src/pages/index.ts
@@ -20,3 +20,11 @@ export { default as MyPostsPage } from "./my/MyPostsPage";
 export { default as SupportDetailPage } from "./support/SupportDetailPage";
 export { default as SupportPage } from "./support/SupportPage";
 export { default as SupportWritePage } from "./support/SupportWritePage";
+export {
+  AdminHomePage,
+  AdminSupportPage,
+  AdminActivityPage,
+  AdminLibraryPage,
+  AdminReportPage,
+  AdminMemberPage,
+} from "./admin";

--- a/apps/member/src/utils/admin.ts
+++ b/apps/member/src/utils/admin.ts
@@ -1,0 +1,24 @@
+import type { MemberRole } from "@/api/member";
+
+export type AdminMemberPendingAction =
+  | { type: "role"; memberId: string; name: string; role: MemberRole }
+  | { type: "password"; memberId: string; name: string }
+  | { type: "delete"; memberId: string; name: string }
+  | { type: "approve"; recruitmentId: number; studentId: string; name: string }
+  | { type: "reject"; recruitmentId: number; studentId: string; name: string };
+
+export function getConfirmMessage(action: AdminMemberPendingAction) {
+  if (action.type === "role") {
+    return `${action.name} 회원의 권한을 ${action.role}(으)로 변경하시겠습니까?`;
+  }
+  if (action.type === "password") {
+    return `${action.name} 회원에게 비밀번호 재설정 메일을 보냅니다.`;
+  }
+  if (action.type === "delete") {
+    return `${action.name} 회원을 정말 삭제하시겠습니까?`;
+  }
+  if (action.type === "approve") {
+    return `${action.name}님의 가입 신청을 승인하시겠습니까?`;
+  }
+  return `${action.name}님의 가입 신청을 거절하시겠습니까?`;
+}

--- a/apps/member/src/utils/member.ts
+++ b/apps/member/src/utils/member.ts
@@ -1,0 +1,15 @@
+import type { MemberRole, StudentStatus } from "@/api/member";
+
+export function getRoleColor(role: MemberRole) {
+  if (role === "SUPER") return "red";
+  if (role === "ADMIN") return "purple";
+  if (role === "USER") return "green";
+  return "disabled";
+}
+
+export function formatStudentStatus(status?: StudentStatus | string) {
+  if (status === "CURRENT") return "재학";
+  if (status === "ON_LEAVE") return "휴학";
+  if (status === "GRADUATED") return "졸업";
+  return status ?? "-";
+}

--- a/packages/design-system/src/components/tabs/Tabs.tsx
+++ b/packages/design-system/src/components/tabs/Tabs.tsx
@@ -8,9 +8,10 @@ export interface TabsProps extends HTMLAttributes<HTMLElement> {
 }
 
 interface TabsItemProps extends HTMLAttributes<HTMLButtonElement> {
-  icon: ReactNode;
   label: string;
   href: string;
+  icon?: ReactNode;
+  endSlot?: ReactNode;
 }
 
 export default function Tabs({ className, children, ...props }: TabsProps) {
@@ -24,7 +25,7 @@ export default function Tabs({ className, children, ...props }: TabsProps) {
   );
 }
 
-function TabsItem({ className, icon, label, href, ...props }: TabsItemProps) {
+function TabsItem({ className, icon, label, href, endSlot, ...props }: TabsItemProps) {
   const location = useLocation();
   const navigate = useNavigate();
 
@@ -46,14 +47,17 @@ function TabsItem({ className, icon, label, href, ...props }: TabsItemProps) {
       onClick={() => navigate(href)}
       {...props}
     >
-      <span className={cn('text-gray-300', isActive && 'text-primary')}>
-        {cloneElement(icon as ReactElement<IconBaseProps>, {
-          size: 16,
-        })}
-      </span>
+      {icon && (
+        <span className={cn('text-gray-300', isActive && 'text-primary')}>
+          {cloneElement(icon as ReactElement<IconBaseProps>, {
+            size: 16,
+          })}
+        </span>
+      )}
       <span className={cn('font-size-18 font-semibold text-gray-300', isActive && 'text-primary')}>
         {label}
       </span>
+      {endSlot}
     </button>
   );
 }


### PR DESCRIPTION
## Summary
- AdminMemberPage 내부 컴포넌트/유틸 함수를 파일 단위로 분리
- AdminActivityPage의 ActivityAdminCard를 컴포넌트로 분리
- admin 컴포넌트 barrel export 추가

## Checks
- pnpm --filter @clab/member lint
- pnpm --filter @clab/member build
- pnpm --filter @clab/member test

Closes #46